### PR TITLE
Don't Pull Strava Runs With No Coords

### DIFF
--- a/server/api/users.js
+++ b/server/api/users.js
@@ -74,9 +74,13 @@ router.get('/:id/strava', (req, res, next) => {
   .then(stravaId => {
     if (!stravaId) return;
     axios.get('https://www.strava.com/api/v3/athlete/activities', { headers: {'Authorization': stravaQueryHeaders} })
-    .then(res => res.data[0])
-    .then(run => {
-      res.json(run)
+    .then(res => res.data)
+    .then(data => {
+      let runIdx = 0;
+      while (!data[runIdx].end_latlng) {
+        runIdx++
+      }
+      res.json(data[runIdx])
     })
   })
 })


### PR DESCRIPTION
- Changed backend api to prevent pulling latest run from strava if it doesn't have ending lat/lang (moves to next run with end_latlng)